### PR TITLE
Add upload capability to dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-# Earthsafe-Textractdbd
+# Earthsafe Textract Prototype
+
+This repository contains a small prototype for digitizing gold production records. It shows how to use **Amazon Textract** to process scanned receipts and view the extracted information from a simple dashboard.
+
+## Setup
+
+1. Install the requirements (preferably in a virtual environment):
+
+   ```bash
+   pip install -r app/requirements.txt
+   ```
+
+2. Configure AWS credentials so that `boto3` can access Amazon Textract.
+
+## Processing a Document
+
+You can also run `process_documents.py` directly with the path to a scanned image file:
+
+```bash
+python app/process_documents.py /path/to/receipt.jpg
+```
+
+The script saves extracted data to `processed_data.json`.
+
+## Viewing the Dashboard
+
+Start the Flask application:
+
+```bash
+python app/app.py
+```
+
+Open `http://localhost:5000` in a browser. Use the upload form to select an image file and click **Extract**. The detected text will appear on the page.
+
+This is a basic example intended for experimentation. It can be extended to store data in a real database and include user authentication for a production deployment.

--- a/app/app.py
+++ b/app/app.py
@@ -1,0 +1,61 @@
+from flask import Flask, render_template_string, request, redirect, url_for
+import json
+from pathlib import Path
+from process_documents import extract_text_from_file, save_record
+
+UPLOAD_FOLDER = Path('uploads')
+UPLOAD_FOLDER.mkdir(exist_ok=True)
+
+app = Flask(__name__)
+
+data_file = Path('processed_data.json')
+
+template = """
+<!doctype html>
+<html>
+  <head>
+    <title>Production Records</title>
+  </head>
+  <body>
+    <h1>Processed Documents</h1>
+    <form method="post" enctype="multipart/form-data">
+      <input type="file" name="file" required>
+      <button type="submit">Extract</button>
+    </form>
+    {% if records %}
+      <ul>
+        {% for r in records %}
+          <li>
+            <strong>{{ r.file_name }}</strong> - {{ r.timestamp }}<br>
+            <pre>{{ r.extracted_text }}</pre>
+          </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p>No records found.</p>
+    {% endif %}
+  </body>
+</html>
+"""
+
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    if request.method == 'POST':
+        uploaded = request.files.get('file')
+        if uploaded and uploaded.filename:
+            file_path = UPLOAD_FOLDER / uploaded.filename
+            uploaded.save(file_path)
+            text = extract_text_from_file(file_path)
+            save_record(uploaded.filename, text)
+            return redirect(url_for('index'))
+
+    records = []
+    if data_file.exists():
+        with open(data_file, 'r') as f:
+            records = json.load(f)
+    return render_template_string(template, records=records)
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/app/process_documents.py
+++ b/app/process_documents.py
@@ -1,0 +1,41 @@
+import argparse
+import json
+import boto3
+from datetime import datetime
+from pathlib import Path
+
+
+def extract_text_from_file(file_path):
+    client = boto3.client('textract')
+    with open(file_path, 'rb') as document:
+        image_bytes = document.read()
+
+    response = client.detect_document_text(Document={'Bytes': image_bytes})
+    lines = [item['Text'] for item in response.get('Blocks', []) if item['BlockType'] == 'LINE']
+    return '\n'.join(lines)
+
+
+def save_record(file_name, extracted_text, output_file='processed_data.json'):
+    record = {
+        'file_name': file_name,
+        'extracted_text': extracted_text,
+        'timestamp': datetime.utcnow().isoformat()
+    }
+    data = []
+    path = Path(output_file)
+    if path.exists():
+        with open(path, 'r') as f:
+            data = json.load(f)
+    data.append(record)
+    with open(path, 'w') as f:
+        json.dump(data, f, indent=2)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Process scanned documents using Amazon Textract.')
+    parser.add_argument('file', help='Path to the scanned image file')
+    args = parser.parse_args()
+
+    text = extract_text_from_file(args.file)
+    save_record(args.file, text)
+    print(f"Processed {args.file}")

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+boto3


### PR DESCRIPTION
## Summary
- allow uploading images to extract text directly from the dashboard
- update documentation with new instructions

## Testing
- `python -m py_compile app/app.py app/process_documents.py`


------
https://chatgpt.com/codex/tasks/task_e_6866efe1d418832c92f5eeade8425e71